### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,36 +7,36 @@
 ####################################################
 #   Classes (KEYWORD1)
 ####################################################
-PWF_AS3935							KEYWORD1
+PWF_AS3935	KEYWORD1
 
 
 ####################################################
 #   Functions (KEYWORD2)
 ####################################################
-AS3935_DefInit							KEYWORD2
-_AS3935_Reset							KEYWORD2
-_CalRCO									KEYWORD2
-AS3935_PowerUp							KEYWORD2
-AS3935_PowerDown						KEYWORD2
-AS3935_DisturberEn						KEYWORD2
-AS3935_DisturberDis						KEYWORD2
-AS3935_SetIRQ_Output_Source				KEYWORD2
-AS3935_SetTuningCaps					KEYWORD2
-AS3935_GetInterruptSrc					KEYWORD2
-AS3935_GetLightningDistKm				KEYWORD2
-AS3935_SetMinStrikes					KEYWORD2
-AS3935_SetIndoors						KEYWORD2
-AS3935_SetOutdoors						KEYWORD2
-AS3935_ClearStatistics					KEYWORD2
-AS3935_GetNoiseFloorLvl					KEYWORD2
-AS3935_SetNoiseFloorLvl					KEYWORD2
-AS3935_GetWatchdogThreshold				KEYWORD2
-AS3935_SetWatchdogThreshold				KEYWORD2
-AS3935_GetSpikeRejection				KEYWORD2
-AS3935_SetSpikeRejection				KEYWORD2
-AS3935_SetLCO_FDIV						KEYWORD2
-AS3935_PrintAllRegs						KEYWORD2
-AS3935_ManualCal						KEYWORD2
+AS3935_DefInit	KEYWORD2
+_AS3935_Reset	KEYWORD2
+_CalRCO	KEYWORD2
+AS3935_PowerUp	KEYWORD2
+AS3935_PowerDown	KEYWORD2
+AS3935_DisturberEn	KEYWORD2
+AS3935_DisturberDis	KEYWORD2
+AS3935_SetIRQ_Output_Source	KEYWORD2
+AS3935_SetTuningCaps	KEYWORD2
+AS3935_GetInterruptSrc	KEYWORD2
+AS3935_GetLightningDistKm	KEYWORD2
+AS3935_SetMinStrikes	KEYWORD2
+AS3935_SetIndoors	KEYWORD2
+AS3935_SetOutdoors	KEYWORD2
+AS3935_ClearStatistics	KEYWORD2
+AS3935_GetNoiseFloorLvl	KEYWORD2
+AS3935_SetNoiseFloorLvl	KEYWORD2
+AS3935_GetWatchdogThreshold	KEYWORD2
+AS3935_SetWatchdogThreshold	KEYWORD2
+AS3935_GetSpikeRejection	KEYWORD2
+AS3935_SetSpikeRejection	KEYWORD2
+AS3935_SetLCO_FDIV	KEYWORD2
+AS3935_PrintAllRegs	KEYWORD2
+AS3935_ManualCal	KEYWORD2
 
 ####################################################
 #   Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords